### PR TITLE
Make convert.convertFiles public

### DIFF
--- a/pkg/convert/convert.go
+++ b/pkg/convert/convert.go
@@ -17,7 +17,7 @@ type Options struct {
 	Verbose bool
 }
 
-func convertFiles(files []os.FileInfo, inputPath string, outputPath string, opt Options) error {
+func ConvertFiles(files []os.FileInfo, inputPath string, outputPath string, opt Options) error {
 	cropFlag := ""
 	if opt.Crop != "" {
 		cropFlag = ",crop="


### PR DESCRIPTION
Depending on the use cases, some people will prefer providing individual files instead of an entier folder's videos. Especially if that folder does not contain only videos, as I don't see anything preventing the function from feeding e.g. an image file into `convertFiles`, which will obviously result in some error from ffmpeg